### PR TITLE
Grammar in example app: 'catched' → 'caught'

### DIFF
--- a/actions_app/scenes/NotificationCenterViewController.swift
+++ b/actions_app/scenes/NotificationCenterViewController.swift
@@ -23,7 +23,7 @@ class NotificationCenterViewController: BaseViewController {
             
             if observing {
                 NotificationCenter.default.add(observer: self, name: .notification1) { [unowned self] in
-                    self.showAlert(message: "Notification 1 catched")
+                    self.showAlert(message: "Notification 1 caught")
                 }
             }
             else {
@@ -47,7 +47,7 @@ class NotificationCenterViewController: BaseViewController {
         observing = false
         
         NotificationCenter.default.add(observer: self, name: .notification2) { [unowned self] in
-            self.showAlert(message: "Notification 2 catched")
+            self.showAlert(message: "Notification 2 caught")
         }
     }
 


### PR DESCRIPTION
While 'catched' is actually [good grammatical English](https://en.wiktionary.org/wiki/catched), since it hasn't been in use since the War of 1812, most people will presume that [it's just wrong](http://www.urbandictionary.com/define.php?term=Catched).